### PR TITLE
Add tag and untag command parsing for improved task management

### DIFF
--- a/src/main/java/moody/commands/AddTagCommand.java
+++ b/src/main/java/moody/commands/AddTagCommand.java
@@ -1,0 +1,39 @@
+package moody.commands;
+
+import moody.exceptions.InvalidCommandException;
+import moody.storage.Storage;
+import moody.tasks.Task;
+import moody.tasks.TaskList;
+import moody.ui.Ui;
+
+import java.io.IOException;
+
+/**
+ * Represents a command to add a tag to a task.
+ */
+public class AddTagCommand extends Command {
+    private final int taskIndex;
+    private final String tag;
+
+    /**
+     * Constructs an {@code AddTagCommand} with the specified task index and tag.
+     *
+     * @param taskIndex The index of the task to tag.
+     * @param tag The tag to add.
+     */
+    public AddTagCommand(int taskIndex, String tag) {
+        this.taskIndex = taskIndex;
+        this.tag = tag;
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) throws InvalidCommandException, IOException {
+        if (taskIndex < 0 || taskIndex >= tasks.size()) {
+            throw new InvalidCommandException("Error: Task index out of bounds.\n");
+        }
+        Task task = tasks.get(taskIndex);
+        task.addTag(tag);
+        storage.save(tasks.toArrayList());
+        return "Tag added: " + tag + "\n" + task;
+    }
+}

--- a/src/main/java/moody/commands/RemoveTagCommand.java
+++ b/src/main/java/moody/commands/RemoveTagCommand.java
@@ -1,0 +1,43 @@
+package moody.commands;
+
+import moody.exceptions.InvalidCommandException;
+import moody.storage.Storage;
+import moody.tasks.Task;
+import moody.tasks.TaskList;
+import moody.ui.Ui;
+
+import java.io.IOException;
+
+/**
+ * Represents a command to remove a tag from a task.
+ */
+public class RemoveTagCommand extends Command {
+    private final int taskIndex;
+    private final String tag;
+
+    /**
+     * Constructs a {@code RemoveTagCommand} with the specified task index and tag.
+     *
+     * @param taskIndex The index of the task to untag.
+     * @param tag The tag to remove.
+     */
+    public RemoveTagCommand(int taskIndex, String tag) {
+        this.taskIndex = taskIndex;
+        this.tag = tag;
+    }
+
+    @Override
+    public String execute(TaskList tasks, Ui ui, Storage storage) throws InvalidCommandException, IOException {
+        if (taskIndex < 0 || taskIndex >= tasks.size()) {
+            throw new InvalidCommandException("Error: Task index out of bounds.\n");
+        }
+
+        Task task = tasks.get(taskIndex);
+        if (task.removeTag(tag)) {
+            storage.save(tasks.toArrayList()); // Save the updated list
+            return "Tag removed: " + tag + "\n" + task;
+        } else {
+            return "Tag not found: " + tag;
+        }
+    }
+}

--- a/src/main/java/moody/parser/Parser.java
+++ b/src/main/java/moody/parser/Parser.java
@@ -59,6 +59,12 @@ public class Parser {
         case "find":
             return parseFindCommand(arguments);
 
+        case "tag":
+            return parseTagCommand(arguments);
+
+        case "untag":
+            return parseUntagCommand(arguments);
+
         default:
             throw new InvalidCommandException("""
             Error: Command not found
@@ -198,5 +204,27 @@ public class Parser {
         } catch (NumberFormatException e) {
             throw new TaskInputException("Error: Invalid task number.");
         }
+    }
+
+    private static Command parseTagCommand(String arguments) throws TaskInputException {
+        String[] parts = arguments.split(" ", 2);
+        if (parts.length != 2 || parts[1].trim().isEmpty()) {
+            throw new TaskInputException("Error: The task index and tag cannot be empty.\n");
+        }
+
+        int taskIndex = parseTaskIndex(parts[0]);
+        String tag = parts[1].trim();
+        return new AddTagCommand(taskIndex, tag);
+    }
+
+    private static Command parseUntagCommand(String arguments) throws TaskInputException {
+        String[] parts = arguments.split(" ", 2);
+        if (parts.length != 2 || parts[1].trim().isEmpty()) {
+            throw new TaskInputException("Error: The task index and tag cannot be empty.\n");
+        }
+
+        int taskIndex = parseTaskIndex(parts[0]);
+        String tag = parts[1].trim();
+        return new RemoveTagCommand(taskIndex, tag);
     }
 }

--- a/src/main/java/moody/tasks/Task.java
+++ b/src/main/java/moody/tasks/Task.java
@@ -1,5 +1,8 @@
 package moody.tasks;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Represents a task with a description and completion status.
  * The Task class provides methods to manage and display the task's status.
@@ -7,6 +10,7 @@ package moody.tasks;
 public class Task {
     protected String description;
     protected boolean isDone;
+    protected Set<String> tags;
 
     /**
      * Creates a Task with the specified description.
@@ -17,6 +21,7 @@ public class Task {
     public Task(String description) {
         this.description = description;
         this.isDone = false;
+        this.tags = new HashSet<>();
     }
 
     /**
@@ -50,23 +55,52 @@ public class Task {
     }
 
     /**
+     * Adds a tag to the Task.
+     * Tags are managed in a set to avoid duplicates.
+     *
+     * @param tag The tag to be added.
+     */
+    public void addTag(String tag) {
+        tags.add(tag);
+    }
+
+    /**
+     * Removes a tag from the Task.
+     *
+     * @param tag The tag to be removed.
+     * @return True if the tag was removed successfully, false otherwise.
+     */
+    public boolean removeTag(String tag) {
+        return tags.remove(tag);
+    }
+
+    /**
+     * Retrieves all tags associated with the Task.
+     *
+     * @return A set of tags associated with the Task.
+     */
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    /**
      * Converts the Task to a format suitable for saving to a file.
-     * The format includes the completion status and the description.
+     * The format includes the completion status, description and tags.
      *
      * @return A string representation of the Task in file format.
      */
     public String toFileFormat() {
-        return (isDone ? "1" : "0") + " | " + this.description;
+        return (isDone ? "1" : "0") + " | " + this.description + String.join(",", tags);
     }
 
     /**
      * Returns a string representation of the Task for display purposes.
-     * The format includes the status icon and the description.
+     * The format includes the status icon, description and taqss
      *
      * @return A string representation of the Task.
      */
     @Override
     public String toString() {
-        return String.format("[%s] %s", getStatusIcon(), this.description);
+        return String.format("[%s] %s %s", getStatusIcon(), this.description, tags.isEmpty() ? "" : tags);
     }
 }


### PR DESCRIPTION
Previously, there was no support for tagging tasks in the CLI. Adding tag and untag functionality enhances the ability to categorize and manage tasks effectively.

Let's implement parseTagCommand and parseUntagCommand to allow users to tag tasks with descriptive labels, improving task organization and retrieval.

Let's also ensure that the new tag and untag commands are compatible with existing command parsing logic and provide appropriate error messages for invalid inputs.